### PR TITLE
Openscad option to split the spacer layer of the case into fourths.

### DIFF
--- a/case/openscad/atreus_case.scad
+++ b/case/openscad/atreus_case.scad
@@ -57,6 +57,12 @@ cable_hole_width = 12;
    be zero. */
 staggering_offsets = [0, 5, 11, 6, 3];
 
+/* Whether or not to split the spacer into quarters. */
+quarter_spacer = false;
+
+/* Where the top/bottom split of a quartered spacer will be. */
+spacer_quartering_offset = 60;
+
 module rz(angle, center=undef) {
   /* Rotate children `angle` degrees around `center`. */
   translate(center) {
@@ -286,8 +292,34 @@ module spacer() {
   }
 }
 
+module spacer_quadrant(spacer_quadrant_number) {
+  /* Cut a quarter of a spacer. */
+  translate([0, spacer_quartering_offset]) {
+    intersection() {
+      translate([0, -spacer_quartering_offset]) { spacer(); }
+      rotate([0, 0, spacer_quadrant_number * 90]) { square([1000, 1000]); }
+    }
+  }
+}
+
+module quartered_spacer()
+{
+  /* Assemble all four quarters of a spacer. */
+  spacer_quadrant(0);
+  spacer_quadrant(1);
+  translate([-5,-10]) spacer_quadrant(2);
+  translate([5,-10]) spacer_quadrant(3);
+}
+
 /* Create all four layers. */
 top_plate();
-translate([300, 150]) { spacer(); }
 translate([300, 0]) { switch_plate(); }
 translate([0, 150]) { bottom_plate(); }
+translate([300, 150]) {
+  if (quarter_spacer == true) {
+    quartered_spacer();
+  }
+  else {
+    spacer();
+  }
+}


### PR DESCRIPTION
I've added a little code that allows for splitting the spacer layer of the case into fourths, giving more flexbility in fitting the pieces onto a sheet for laser cutting (specifically, I wanted to fit it all onto one P2 sheet of 3mm acrylic from Ponoko).  Kudos for inspiration goes to [this geekhack thread by Constantine](https://geekhack.org/index.php?topic=57007.0).

I'm still waiting on my Ponoko order to arrive in the mail, so you may want to wait until I've tested that it all fits nicely before merging.