### PR TITLE
Consider hand separation when placing cable screws

### DIFF
--- a/case/openscad/atreus_case.scad
+++ b/case/openscad/atreus_case.scad
@@ -222,7 +222,7 @@ module right_screw_holes(hole_radius) {
   }
 
   /* add the screw hole near the cable hole */
-  translate([washer_radius - tmp[0],
+  translate([washer_radius - tmp[0] - 0.5*hand_separation,
              back_screw_hole_offset]) {
     rotate_half() {
       add_hand_separation() {


### PR DESCRIPTION
When increasing the hand_separation screw holes near the USB hole were getting farther apart but the cut for the usb hole is fixed. As the hands separate the screw holes need to be negatively offset.